### PR TITLE
Allow reader conditionals in read-form

### DIFF
--- a/src/niddle/print.clj
+++ b/src/niddle/print.clj
@@ -76,7 +76,7 @@
 (def ^:dynamic *debug* false)
 (def skippable-sym #{'in-ns 'find-ns '*ns*})
 
-(defn read-form [code] (if (string? code) (read-string code) code))
+(defn read-form [code] (if (string? code) (read-string {:read-cond :allow} code) code))
 
 (defn print-form? [form]
   "Skip functions & symbols that are unnecessary outside of interactive REPL"

--- a/test/niddle/print_test.clj
+++ b/test/niddle/print_test.clj
@@ -13,7 +13,9 @@
     (are [form] (= (read-form form) form)
       1 :key [1 2 3] '(identity 1)))
   (is (read-form "#(identity %)")
-      "Can extract forms with reader macro"))
+      "Can extract forms with reader macro")
+  (is (= :yep (read-form "#?(:clj :yep :cljs :nope)"))
+      "Can extract forms with reader conditional"))
 
 (deftest print-form?-test
   (testing "Forms that should be printed"


### PR DESCRIPTION
Will resolve https://github.com/Olical/conjure/issues/128

Conjure sends reader conditionals as part of it's core mechanics, this breaks if niddle is being used in the nREPL. Or maybe it doesn't break but results in a bunch of errors in the REPL.